### PR TITLE
drop support for node 10 in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,7 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: '*'
   pull_request:
     branches: [ master ]
 
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x, 17.x, 18.x, 19.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Support all modern node versions from 12.x through to 19